### PR TITLE
Match array type parsing behavior with a strings 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ export default function createSocketIoMiddleware(socket, option = [],
           emit = option(type);
         } else if (Array.isArray(option)) {
           // Array of types
-          emit = option.some((item) => type.indexOf(option) === 0);
+          emit = option.some((item) => type.indexOf(item) === 0);
         }
 
         if (emit) {

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ export default function createSocketIoMiddleware(socket, option = [],
           emit = option(type);
         } else if (Array.isArray(option)) {
           // Array of types
-          emit = option.indexOf(type) !== -1;
+          emit = option.some((item) => type.indexOf(option) === 0);
         }
 
         if (emit) {

--- a/test/index.js
+++ b/test/index.js
@@ -47,6 +47,27 @@ suite('Redux-socket.io middleware basic tests', () => {
     expect(socket.emitted[0][1].type).toBe('server/socketAction1');
     expect(socket.emitted[0][1].payload).toBe('action1');
   });
+  
+  test('Using an array of action names and prefixes to determine whether to call socket', () => {
+    const socket = new MockSocket();
+    const socketIoMiddleware = createSocketIoMiddleware(socket, ['server/socketAction1', 'action2']);
+    const createStoreWithMiddleware = applyMiddleware(socketIoMiddleware)(createStore);
+    const store = createStoreWithMiddleware(simpleReducer);
+
+    store.dispatch({ type: 'server/socketAction1', payload: 'action1' });
+    store.dispatch({ type: 'action2', payload: 'action2' });
+    store.dispatch({ type: 'action3', payload: 'action3' });
+
+    expect(store.getState().socketAction1).toBe('action1');
+    expect(store.getState().action2).toBe('action2');
+    expect(socket.emitted.length).toBe(2);
+    expect(socket.emitted[0][0]).toBe('action');
+    expect(socket.emitted[0][1].type).toBe('server/socketAction1');
+    expect(socket.emitted[0][1].payload).toBe('action1');
+    expect(socket.emitted[1][0]).toBe('action');
+    expect(socket.emitted[1][1].type).toBe('action2');
+    expect(socket.emitted[1][1].payload).toBe('action2');
+  });
 
   test('Using a function to determine whether to call socket', () => {
     const socket = new MockSocket();
@@ -99,6 +120,10 @@ function simpleReducer(state = {}, action) {
     case 'action2':
       return Object.assign({}, state, {
         action2: action.payload,
+      });
+    case 'action3':
+      return Object.assign({}, state, {
+        action3: action.payload,
       });
     default:
       return state;


### PR DESCRIPTION
If one passes a prefix as a string, then the library matches correctly, (ie, `server/` against `server/ACTION`). In an array, this wasn't the case before - this change fixes that (so, ["server/", "ANOTHER_ACTION"] will match against `server/ACTION` and `server/SOMETHING_ELSE` and `ANOTHER_ACTION`).

I'm pretty sure you this was unintended when you wrote the library, and in my use of it this was a glaring issue.

Let me know if I missed something or misinterpreted toe code or its respective test. All tests still pass.
