### PR TITLE
Pass entire action object to the option function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ export default function createSocketIoMiddleware(socket, option = [],
           emit = type.indexOf(option) === 0;
         } else if (typeof option === 'function') {
           // Test function
-          emit = option(type);
+          emit = option(type, action);
         } else if (Array.isArray(option)) {
           // Array of types
           emit = option.some((item) => type.indexOf(item) === 0);


### PR DESCRIPTION
Hey there.  For my scenario I wanted to toggle whether an action gets sent over the socket not by its name, but instead by a property on the action object itself.  Real simple change, I included the action object as the second parameter to the option function, making this possible.

Thought it might be generally useful, and doesn't break existing usage, so... Here's a tiny PR.

I didn't re-generate the dist, as I'm not sure how you prefer to manage that, so I had to update the test path to point at the src.  Hope it's not too much of a bother.

Cheers!
