### PR TITLE
Match peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,10 @@
   "author": "ian.b.taylor@gmail.com",
   "license": "MIT",
   "devDependencies": {
-    "babel-eslint": "^5.0.0",
+    "babel-eslint": "^6.0.2",
     "babel-preset-es2015": "^6.5.0",
     "babel-register": "^6.5.2",
+    "eslint": "^2.6.0",
     "eslint-config-airbnb": "^6.2.0",
     "eslint-plugin-babel": "^3.1.0",
     "eslint-plugin-react": "^4.2.3",


### PR DESCRIPTION
Add `eslint` and upgrade `babel-eslint` so a consensus in `eslint` version is reached.
Fixes the warning which shows up during `npm install`.
