### PR TITLE
Better chainability

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -3,9 +3,6 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
-
 exports.default = createSocketIoMiddleware;
 
 /**
@@ -48,7 +45,7 @@ function createSocketIoMiddleware(socket) {
   };
 
   function evaluate(action, option) {
-    if (!action || (typeof action === 'undefined' ? 'undefined' : _typeof(action)) !== 'object' || !action.hasOwnProperty('type')) {
+    if (!action || !action.type) {
       return false;
     }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -3,6 +3,9 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
 exports.default = createSocketIoMiddleware;
 
 /**
@@ -36,15 +39,19 @@ function createSocketIoMiddleware(socket) {
     return function (next) {
       return function (action) {
         if (evaluate(action, criteria)) {
-          execute(action, emitBound, next, dispatch);
+          return execute(action, emitBound, next, dispatch);
         } else {
-          next(action);
+          return next(action);
         }
       };
     };
   };
 
   function evaluate(action, option) {
+    if (!action || (typeof action === 'undefined' ? 'undefined' : _typeof(action)) !== 'object' || !action.hasOwnProperty('type')) {
+      return false;
+    }
+
     var type = action.type;
 
     var matched = false;
@@ -66,6 +73,6 @@ function createSocketIoMiddleware(socket) {
   function defaultExecute(action, emit, next, dispatch) {
     // eslint-disable-line no-unused-vars
     emit(eventName, action);
-    next(action);
+    return next(action);
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "test"
   },
   "scripts": {
-    "test": "mocha --ui tdd --compilers js:babel-register"
+    "build": "gulp",
+    "test": "npm run build && mocha --ui tdd --compilers js:babel-register"
   },
   "keywords": [
     "redux",

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ export default function createSocketIoMiddleware(socket, criteria = [],
   };
 
   function evaluate(action, option) {
-    if (!action || typeof action !== 'object' || !action.hasOwnProperty('type')) {
+    if (!action || !action.type) {
       return false;
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -20,9 +20,9 @@ export default function createSocketIoMiddleware(socket, criteria = [],
     socket.on(eventName, dispatch);
     return next => action => {
       if (evaluate(action, criteria)) {
-        execute(action, emitBound, next, dispatch);
+        return execute(action, emitBound, next, dispatch);
       } else {
-        next(action);
+        return next(action);
       }
     };
   };
@@ -31,7 +31,7 @@ export default function createSocketIoMiddleware(socket, criteria = [],
     if (!action || typeof action !== 'object' || !action.hasOwnProperty('type')) {
       return false;
     }
-    
+
     const { type } = action;
     let matched = false;
     if (typeof option === 'function') {
@@ -49,6 +49,6 @@ export default function createSocketIoMiddleware(socket, criteria = [],
 
   function defaultExecute(action, emit, next, dispatch) { // eslint-disable-line no-unused-vars
     emit(eventName, action);
-    next(action);
+    return next(action);
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,10 @@ export default function createSocketIoMiddleware(socket, criteria = [],
   };
 
   function evaluate(action, option) {
+    if (!action || typeof action !== 'object' || !action.hasOwnProperty('type')) {
+      return false;
+    }
+    
     const { type } = action;
     let matched = false;
     if (typeof option === 'function') {

--- a/test/index.js
+++ b/test/index.js
@@ -177,6 +177,14 @@ suite('Better chainability', () => {
     const actionHandler = nextHandler(next);
     expect(() => actionHandler(actionAsFunction)).toNotThrow();
   });
+
+  test('Return the return value of next', () => {
+    const expected = 'value';
+    const next = action => action.payload;
+    const actionHandler = nextHandler(next);
+    const action = { type: 'test', payload: expected };
+    expect(actionHandler(action)).toEqual(expected);
+  });
 });
 
 function simpleReducer(state = {}, action) {

--- a/test/index.js
+++ b/test/index.js
@@ -163,6 +163,22 @@ suite('Redux-socket.io middleware basic tests', () => {
   });
 });
 
+suite('Better chainability', () => {
+  let socket = new MockSocket();
+  let socketIoMiddleware = createSocketIoMiddleware(socket, 'server/');
+  let doDispatch = () => {};
+  let doGetState = () => {};
+  let nextHandler = socketIoMiddleware({ dispatch: doDispatch, getState: doGetState})
+
+  // https://github.com/itaylor/redux-socket.io/pull/17
+  test('Support functions as actions', () => {
+    const actionAsFunction = () => {};
+    const next = () => {};
+    const actionHandler = nextHandler(next);
+    expect(() => actionHandler(actionAsFunction)).toNotThrow();
+  });
+});
+
 function simpleReducer(state = {}, action) {
   switch (action.type) {
     case 'server/socketAction1':


### PR DESCRIPTION
Hi, thanks for creating and sharing this library.

I used it recently to provide realtime features in our app but few things started to break.

First, we needed to register this middleware as the last middleware because it does not support actions which are not objects. Liked noted in [this PR](https://github.com/itaylor/redux-socket.io/pull/17)

Second, it's common for us to do chaining like:

```dispatch(save(entity)).then(entity => dispatch(entitySaved(entity)))```

After adding this middleware, the next function called in the `then` statement won't get the parameter due to the middleware not returning the value from the previous executed function.

This PR fixes both issues which I am sure will improve the usage of this middleware in conjunction to other popular ones.

Additionally, I also added a npm script to build the dist file. I run this script before running tests so that tests run over the latest distribution file.