### PR TITLE
Use the extra setting to enable user to dispatch action as socket receives event

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -120,6 +120,43 @@ function optimisticExecute(action, emit, next, dispatch) {
 let socketIoMiddleware = createSocketIoMiddleware(socket, "server/", { execute: optimisticExecute });
 ```
 
+### Example customized socket listener: ###
+Use the extra prameter `listeners` to specific the action `<actionName>`, 
+which would be dispatched with arguments `msg.argumens` as socket receives the msg with 
+specific message `msg.type = action/<actionName>`
+
+Client side:
+```js
+import createSocketIoMiddleware from 'redux-socket.io';
+
+// Function to send action to server through socket
+function updateTitleBySocket(){
+  return {
+    type 'server/updateTitleByServer',
+    payload: {},
+  }
+}
+
+// Function to listen to socket event
+function updateTitleFromSocket(newText){
+  return {
+    type: 'UPDATE_TITLE',
+    payload: { title: newText },
+  }
+}
+
+let socketIoMiddleware = createSocketIoMiddleware(socket, "server/", { listeners: [updateTitleFromSocket] });
+```
+
+Server side:
+```js
+socket.on('action', msg => {
+  if (msg.type === 'server/updateTitleByServer'){
+    socket.emit('action', { type: 'action/updateTitleFromSocket', arguments: ['Hello'] });
+  }
+});
+```
+
 ### MIT License
 Copyright (c) 2015-2016 Ian Taylor
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,15 +9,18 @@
 *   eventName,// a string name to use to send and receive actions from the server.
 *   execute, // a function (action, emit, next, dispatch) that is responsible for
 *            // sending the message to the server.
+*   listeners, // an array contains a set of actions, which would be dispatch depened on
+               // the receive action.type with arguments in action.arguments. 
+               // ex: 'action/someAction' => dispatch 'someAction(action.arguments)'
 * }
 *
 */
 export default function createSocketIoMiddleware(socket, criteria = [],
-  { eventName = 'action', execute = defaultExecute } = {}) {
+  { eventName = 'action', execute = defaultExecute, listeners = [] } = {}) {
   const emitBound = socket.emit.bind(socket);
   return ({ dispatch }) => {
     // Wire socket.io to dispatch actions sent by the server.
-    socket.on(eventName, dispatch);
+    socket.on(eventName, dispatchlisteners(dispatch));
     return next => (action) => {
       if (evaluate(action, criteria)) {
         return execute(action, emitBound, next, dispatch);
@@ -49,5 +52,25 @@ export default function createSocketIoMiddleware(socket, criteria = [],
   function defaultExecute(action, emit, next, dispatch) { // eslint-disable-line no-unused-vars
     emit(eventName, action);
     return next(action);
+  }
+
+  function dispatchlisteners(dispatch) {
+    return function(action) {
+      let typeArr = action.type.split('/');
+      if (typeArr[0] !== 'action'){
+        // dispatch action without prefix 'action/'
+        return dispatch(action);
+      }
+      var matched;
+      listeners.some(item => (
+        (typeof item === 'function' && item.name === typeArr[1]) && (matched = item)
+      ));
+      if (!matched){
+        console.log('No match action: ' + typeArr[1]);
+        // dispatch action not matched action
+        return dispatch(action);
+      }
+      return dispatch(matched.apply(undefined, action.arguments));
+    }
   }
 }


### PR DESCRIPTION
Hi
In some case, I would need the received event to dispatch some action instead of directly send to reducers, especially the some async action.
Hence, I modified the code and add extra parameter to add a list of actions to 'listen' the socket event

It's my first time to open a pull request, so I don't known whether I should follow some coding style or something else.

Many thanks,
chin-yu